### PR TITLE
simplify alt tangent calc and update comment

### DIFF
--- a/src/fit-curve.js
+++ b/src/fit-curve.js
@@ -122,20 +122,17 @@ function fitCubic(points, leftTangent, rightTangent, error, progressCallback) {
     //Fitting failed -- split at max error point and fit recursively
     beziers = [];
 
-    //To create a smooth transition from one curve segment to the next,
-    //we calculate the tangent of the points directly before and after the center,
-    //and use that same tangent both to and from the center point.
-    centerVector = maths.subtract(points[splitPoint - 1], points[splitPoint + 1]);
-    //However, should those two points be equal, the normal tangent calculation will fail.
-    //Instead, we calculate the tangent from that "double-point" to the center point, and rotate 90deg.
-    if((centerVector[0] === 0) && (centerVector[1] === 0)) {
-        //toCenterTangent = createTangent(points[splitPoint - 1], points[splitPoint]);
-        //fromCenterTangent = createTangent(points[splitPoint + 1], points[splitPoint]);
-
+    //To create a smooth transition from one curve segment to the next, we
+    //calculate the line between the points directly before and after the
+    //center, and use that as the tangent both to and from the center point.
+    centerVector = maths.subtract(points[splitPoint-1], points[splitPoint+1]);
+    //However, this won't work if they're the same point, because the line we
+    //want to use as a tangent would be 0. Instead, we calculate the line from
+    //that "double-point" to the center point, and use its tangent.
+    if ((centerVector[0] === 0) && (centerVector[1] === 0)) {
         //[x,y] -> [-y,x]: http://stackoverflow.com/a/4780141/1869660
-        centerVector = maths.subtract(points[splitPoint - 1], points[splitPoint])
-                            .reverse();
-        centerVector[0] = -centerVector[0];
+        centerVector = maths.subtract(points[splitPoint-1], points[splitPoint]);
+        [centerVector[0],centerVector[1]] = [-centerVector[1],centerVector[0]];
     }
     toCenterTangent = maths.normalize(centerVector);
     //To and from need to point in opposite directions:


### PR DESCRIPTION
We only have to swap x and y instead of reversing the array. Since the array only has x and y it does the same thing, but without calling the array reverse function. This also makes it work with fewer changes if you want to support higher dimensions.